### PR TITLE
Avoid compile error caused by unused log import

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -89,6 +89,9 @@ const (
 	methodPropertySet = "org.freedesktop.DBus.Properties.Set"
 )
 
+// Avoid error caused by unused log import
+var _ = log.Printf
+
 // Interface is a DBus interface implementation.
 type Interface interface {
 	iface() string


### PR DESCRIPTION
When none of the processed interfaces define signals, the log import will
be unused. Add a workaround to ensure that the import is always used.