### PR TITLE
Fix readme: -dest is not a flag for dbus-codegen-go

### DIFF
--- a/_examples/object_manager_client/README.md
+++ b/_examples/object_manager_client/README.md
@@ -9,7 +9,7 @@ go generate
 Now you can list and watch an object manager initial state and changes, for example `org.bluez`: 
 
 ```bash
-go run . -system -dest=org.bluez
+go run . -system org.bluez
 ```
 
 In a parallel console you can trigger events activity:


### PR DESCRIPTION
Fix for https://github.com/amenzhinsky/dbus-codegen-go/issues/3