### PR TITLE
Add len check to signal lookup

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -100,6 +100,9 @@ func LookupSignal(signal *dbus.Signal) (Signal, error) {
 {{- range $iface := .Interfaces}}
 {{- range $signal := $iface.Signals}}
 	case {{ifaceNameConst $iface}} + "." + "{{$signal.Name}}":
+		if len(signal.Body) < {{len $signal.Args}} {
+			return nil, fmt.Errorf("signal has %v args rather than the expected {{len $signal.Args}}", len(signal.Body))
+		}
 {{- range $i, $argument := $signal.Args}}
 		v{{$i}}, ok := signal.Body[{{$i}}].({{$argument.Type}})
 		if !ok {


### PR DESCRIPTION
I've had issues with our code crashing when trying to lookup signals which don't match the expected format. I've added a len check to the code which types the signal to verify the list of args is long enough before trying to type them.